### PR TITLE
Make lsp opt in, reduce configuration size

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "nvim/.config/nvim/pack/plugins/start/nvim-treesitter"]
 	path = nvim/.config/nvim/pack/plugins/start/nvim-treesitter
 	url = https://github.com/nvim-treesitter/nvim-treesitter
+[submodule "nvim/.config/nvim/pack/plugins/start/nvim-lspconfig"]
+	path = nvim/.config/nvim/pack/plugins/start/nvim-lspconfig
+	url = https://github.com/neovim/nvim-lspconfig

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "nvim/.config/nvim/pack/plugins/start/nvim-treesitter"]
 	path = nvim/.config/nvim/pack/plugins/start/nvim-treesitter
 	url = https://github.com/nvim-treesitter/nvim-treesitter
-[submodule "nvim/.config/nvim/pack/plugins/start/nvim-lspconfig"]
-	path = nvim/.config/nvim/pack/plugins/start/nvim-lspconfig
-	url = https://github.com/neovim/nvim-lspconfig

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,9 @@
+{
+  "Lua": {
+    "runtime": { "version": "LuaJIT" },
+    "diagnostics": { "globals": ["vim"] },
+    "workspace": {
+      "checkThirdParty": false
+    }
+  }
+}

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -69,8 +69,8 @@ require("nvim-surround").setup()
 -- ## NVIM.LSP
 vim.lsp.enable({ "lua_ls", "ts_ls", "eslint", "cssls", "nixd" })
 -- TODO >>> add a function to turn off and disable all clients, or alternatively
--- start with them off and add a function to turn them all _on_
-
+-- start with them off and add a function to turn them all _on_.
+-- ALSO >>> sort out the lua rc file so that we get completion!
 -- ## NVIM.AUTOCOMMANDS
 vim.api.nvim_create_autocmd("VimEnter", {
 	callback = function()

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -9,13 +9,7 @@ vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 -- ## PLUGINS.FZF-LUA
 local fzf = require("fzf-lua")
 fzf.setup({
-	fzf_colors = {
-		true, -- take the base inferred colors, apply following overrides
-		["fg"] = { "fg", { "Comment" } },
-		["fg+"] = { "fg", { "PmenuSel" } },
-		["bg+"] = { "bg", { "PmenuSel" } },
-		["hl+"] = { "fg", { "PmenuSel" }, "italic", "underline" },
-	},
+	fzf_colors = true,
 	keymap = {
 		builtin = {
 			["<C-d>"] = "preview-page-down",
@@ -31,6 +25,7 @@ vim.keymap.set("n", "<leader>f", fzf.files)
 vim.keymap.set("n", "<leader>s", fzf.grep_project)
 vim.keymap.set("n", "<leader>h", fzf.helptags)
 vim.keymap.set("n", "<leader>o", fzf.treesitter)
+vim.keymap.set("n", "<leader>c", fzf.highlights)
 
 -- ## PLUGINS.CONFORM
 require("conform").setup({

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -32,7 +32,7 @@ fzf.setup({
 		cwd_prompt = false,
 		winopts = {
 			height = 7,
-			width = 0.5,
+			width = 0.3,
 			row = 2,
 			col = 1,
 			preview = { hidden = true },
@@ -44,7 +44,6 @@ fzf.setup({
 		rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096 -e",
 		winopts = {
 			split = "belowright new",
-			title_pos = "left",
 			title_flags = false,
 			preview = { wrap = true },
 		},
@@ -52,8 +51,12 @@ fzf.setup({
 	helptags = {
 		winopts = {
 			split = "belowright new",
-			title_pos = "left",
 			title_flags = false,
+			preview = {
+				wrap = true,
+				layout = "horizontal",
+				horizontal = "right:70%",
+			},
 		},
 	},
 })

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -66,6 +66,9 @@ require("nvim-treesitter.configs").setup({
 vim.g.tmux_navigator_no_wrap = 1
 require("nvim-surround").setup()
 
+-- ## NVIM.LSP
+vim.lsp.enable({ "lua_ls", "ts_ls", "eslint", "cssls", "nixd" })
+
 -- ## NVIM.AUTOCOMMANDS
 vim.api.nvim_create_autocmd("VimEnter", {
 	callback = function()

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -10,20 +10,11 @@ vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 local fzf = require("fzf-lua")
 fzf.setup({
 	fzf_colors = {
+		true, -- take the base inferred colors, apply following overrides
 		["fg"] = { "fg", { "Comment" } },
-		["hl"] = { "fg", { "Normal" } },
 		["fg+"] = { "fg", { "PmenuSel" } },
 		["bg+"] = { "bg", { "PmenuSel" } },
-		["gutter"] = "-1",
 		["hl+"] = { "fg", { "PmenuSel" }, "italic", "underline" },
-		["query"] = { "fg", { "Cursor" } },
-		["info"] = { "fg", { "Comment" } },
-		["border"] = { "fg", { "Normal" } },
-		["separator"] = { "fg", { "Comment" } },
-		["prompt"] = { "fg", { "Normal" } },
-		["pointer"] = { "fg", { "PmenuSel" } },
-		["marker"] = { "fg", { "Pmenu" } },
-		["header"] = { "fg", { "Normal" } },
 	},
 	keymap = {
 		builtin = {
@@ -31,36 +22,8 @@ fzf.setup({
 			["<C-u>"] = "preview-page-up",
 		},
 	},
-	files = {
-		cwd_prompt = false,
-		winopts = {
-			height = 7,
-			width = 0.3,
-			row = 2,
-			col = 1,
-			preview = { hidden = true },
-			title_pos = "left",
-			title_flags = false,
-		},
-	},
 	grep = {
-		rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096 -e",
-		winopts = {
-			split = "belowright new",
-			title_flags = false,
-			preview = { wrap = true },
-		},
-	},
-	helptags = {
-		winopts = {
-			split = "belowright new",
-			title_flags = false,
-			preview = {
-				wrap = true,
-				layout = "horizontal",
-				horizontal = "right:70%",
-			},
-		},
+		rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096",
 	},
 })
 
@@ -124,16 +87,18 @@ vim.api.nvim_create_autocmd("filetype", {
 		vim.opt_local.cursorcolumn = false
 	end,
 })
+
+-- ## NVIM.NETRW see https://vonheikemen.github.io/devlog/tools/using-netrw-vim-builtin-file-explorer/
 vim.g.netrw_banner = 0
 vim.g.netrw_winsize = 30
 vim.g.netrw_altfile = 1 -- make <C-6> go back to prev file, not netrw
 vim.g.netrw_localcopydircmd = "cp -r" -- allow whole folder copying
+function NetrwWinBar()
+	return "%#Normal#  %t %*%=%#Normal# 󰋞 " .. vim.fn.getcwd() .. " "
+end
 vim.api.nvim_create_autocmd("filetype", {
-	pattern = "netrw", -- netrw configuration, see https://vonheikemen.github.io/devlog/tools/using-netrw-vim-builtin-file-explorer/
+	pattern = "netrw",
 	callback = function()
-		function NetrwWinBar()
-			return "%#Normal#  %t %*%=%#Normal# 󰋞 " .. vim.fn.getcwd() .. " "
-		end
 		vim.opt_local.winbar = "%{%v:lua.NetrwWinBar()%}"
 		vim.keymap.set("n", "h", "-", { remap = true, buffer = true })
 		vim.keymap.set("n", "l", "<cr>", { remap = true, buffer = true })

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -6,14 +6,6 @@ vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 -- SECTION: PLUGINS
 local fzf = require("fzf-lua")
 fzf.setup({
-	keymap = {
-		builtin = {
-			["<C-d>"] = "preview-page-down",
-			["<C-u>"] = "preview-page-up",
-		},
-	},
-	files = { cwd_prompt = false },
-	lsp = { jump_to_single_result = true },
 	fzf_colors = {
 		["fg"] = { "fg", { "Comment" } },
 		["hl"] = { "fg", { "Normal" } },
@@ -30,14 +22,46 @@ fzf.setup({
 		["marker"] = { "fg", { "Pmenu" } },
 		["header"] = { "fg", { "Normal" } },
 	},
-	grep = { rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096 -e" },
+	keymap = {
+		builtin = {
+			["<C-d>"] = "preview-page-down",
+			["<C-u>"] = "preview-page-up",
+		},
+	},
+	files = {
+		cwd_prompt = false,
+		winopts = {
+			height = 7,
+			width = 0.5,
+			row = 2,
+			col = 1,
+			preview = { hidden = true },
+			title_pos = "left",
+			title_flags = false,
+		},
+	},
+	grep = {
+		rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096 -e",
+		winopts = {
+			split = "belowright new",
+			title_pos = "left",
+			title_flags = false,
+			preview = { wrap = true },
+		},
+	},
+	helptags = {
+		winopts = {
+			split = "belowright new",
+			title_pos = "left",
+			title_flags = false,
+		},
+	},
 })
 
 vim.keymap.set("n", "<leader>f", fzf.files)
 vim.keymap.set("n", "<leader>s", fzf.grep_project)
 vim.keymap.set("n", "<leader>h", fzf.helptags)
-vim.keymap.set("n", "<leader>k", fzf.keymaps)
-vim.keymap.set("n", "<leader><leader>", fzf.resume)
+vim.keymap.set("n", "<leader>o", fzf.treesitter)
 
 -- PLUGINS.VIM-TMUX-NAVIGATOR
 vim.g.tmux_navigator_no_wrap = 1
@@ -80,12 +104,6 @@ require("nvim-treesitter.configs").setup({
 	},
 })
 
-function WinBar()
-	local icon = vim.bo.modified and "" or ""
-	return "%*%=%#Normal# " .. icon .. " %t %*%="
-end
-vim.opt.winbar = "%{%v:lua.WinBar()%}"
-
 -- NVIM.AUTOCOMMANDS
 -- Start neovim with fzf open if no arguments passed
 vim.api.nvim_create_autocmd("VimEnter", {
@@ -124,8 +142,7 @@ vim.api.nvim_create_autocmd("filetype", {
 	end,
 })
 
--- TODO extend this to handle loclist in the same way - if you use grr in 0.11, that
--- populates the qf, but using gO (capital o) populates the loclist.
+-- TODO extend this to handle loclist - grr does qflist in 0.11, gO populates loclist
 -- What was previously in /after/ftplugin/qf.lua
 vim.api.nvim_create_autocmd("filetype", {
 	pattern = "qf",
@@ -198,5 +215,10 @@ vim.opt.swapfile = false
 vim.opt.tabstop = 4
 vim.opt.termguicolors = true
 vim.opt.undofile = true
+function WinBar()
+	local icon = vim.bo.modified and "" or ""
+	return "%*%=%#Normal# " .. icon .. " %t %*%="
+end
+vim.opt.winbar = "%{%v:lua.WinBar()%}"
 
 vim.cmd("colorscheme pax")

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,6 +1,7 @@
 -- ## TODOS
 -- create a way to toggle all of the relevant tab settings to move between 2/4 widths
 -- create a supertab for moving through the qf list
+-- fix the hl+ hl group not working!
 -- ## INTRO
 vim.g.mapleader = " "
 vim.g.maplocalleader = " "
@@ -9,7 +10,7 @@ vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 -- ## PLUGINS.FZF-LUA
 local fzf = require("fzf-lua")
 fzf.setup({
-	fzf_colors = true,
+	fzf_colors = { true, ["hl+"] = { "fg", { "PmenuSel" }, "italic", "underline" } },
 	keymap = {
 		builtin = {
 			["<C-d>"] = "preview-page-down",

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -3,7 +3,7 @@
 -- add the ability to start neovim with/without lsp using a flag -- see line 71
 
 -- ## INTRO
-vim.g.vim.g.mapleader = " "
+vim.g.mapleader = " "
 vim.g.maplocalleader = " "
 vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 
@@ -66,11 +66,10 @@ require("nvim-treesitter.configs").setup({
 vim.g.tmux_navigator_no_wrap = 1
 require("nvim-surround").setup()
 
--- ## NVIM.LSP
-vim.lsp.enable({ "lua_ls", "ts_ls", "eslint", "cssls", "nixd" })
+-- ## NVIM.LSP >>> for now just don't enable by default!
+-- vim.lsp.enable({ "lua_ls", "ts_ls", "eslint", "cssls", "nixd" })
 -- TODO >>> add a function to turn off and disable all clients, or alternatively
 -- start with them off and add a function to turn them all _on_.
--- ALSO >>> sort out the lua rc file so that we get completion!
 -- ## NVIM.AUTOCOMMANDS
 vim.api.nvim_create_autocmd("VimEnter", {
 	callback = function()

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,5 +1,6 @@
 -- ## TODOS
 -- fix the hl+ hl group not working in the pax theme!
+-- add the ability to start neovim with/without lsp using a flag
 
 -- ## INTRO
 vim.g.mapleader = " "
@@ -100,13 +101,13 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- ## NVIM.KEYBINDS
-function SetTabSize(size)
+function SetTabSize(size) -- number | nil
 	size = size or 4
 	vim.opt.tabstop = size
 	vim.opt.shiftwidth = size
 	vim.opt.softtabstop = size
 end
-local function super_tab(direction) -- "next" / "previous"
+local function super_tab(direction) -- "next" | "previous"
 	if vim.fn.getqflist({ winid = 0 }).winid ~= 0 then
 		return "<cmd>" .. "c" .. direction .. "<CR>"
 	end

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,9 +1,12 @@
--- SECTION: INTRO
+-- ## TODOS
+-- create a way to toggle all of the relevant tab settings to move between 2/4 widths
+-- create a supertab for moving through the qf list
+-- ## INTRO
 vim.g.mapleader = " "
 vim.g.maplocalleader = " "
 vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 
--- SECTION: PLUGINS
+-- ## PLUGINS.FZF-LUA
 local fzf = require("fzf-lua")
 fzf.setup({
 	fzf_colors = {
@@ -66,13 +69,7 @@ vim.keymap.set("n", "<leader>s", fzf.grep_project)
 vim.keymap.set("n", "<leader>h", fzf.helptags)
 vim.keymap.set("n", "<leader>o", fzf.treesitter)
 
--- PLUGINS.VIM-TMUX-NAVIGATOR
-vim.g.tmux_navigator_no_wrap = 1
-
--- PLUGINS.NVIM-SURROUND
-require("nvim-surround").setup()
-
--- PLUGINS.CONFORM
+-- ## PLUGINS.CONFORM
 require("conform").setup({
 	formatters_by_ft = {
 		javascript = { "prettierd" },
@@ -92,7 +89,7 @@ require("conform").setup({
 	},
 })
 
--- PLUGINS.NVIM-TREESITTER
+-- ## PLUGINS.NVIM-TREESITTER
 -- required for nix compatibility, see https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#advanced-setup
 local parser_install_dir = vim.fn.stdpath("cache") .. "/treesitter"
 vim.opt.runtimepath:append(parser_install_dir)
@@ -107,34 +104,33 @@ require("nvim-treesitter.configs").setup({
 	},
 })
 
--- NVIM.AUTOCOMMANDS
--- Start neovim with fzf open if no arguments passed
+-- ## PLUGINS.VIM-TMUX-NAVIGATOR && PLUGINS.NVIM-SURROUND
+vim.g.tmux_navigator_no_wrap = 1
+require("nvim-surround").setup()
+
+-- ## NVIM.AUTOCOMMANDS
 vim.api.nvim_create_autocmd("VimEnter", {
 	pattern = "*",
 	callback = function()
 		if next(vim.fn.argv()) == nil then
-			require("fzf-lua").files()
+			require("fzf-lua").files() -- open fzf if started with no args
 		end
 	end,
 })
--- Don't show columns in these filetypes
 vim.api.nvim_create_autocmd("filetype", {
-	pattern = { "netrw", "qf", "help" },
+	pattern = { "netrw", "qf", "help" }, -- no visual columns in these files
 	callback = function()
 		vim.opt_local.colorcolumn = ""
 		vim.opt_local.cursorcolumn = false
 	end,
 })
-
--- What was previously in /after/ftplugin/netrw.lua
+vim.g.netrw_banner = 0
+vim.g.netrw_winsize = 30
+vim.g.netrw_altfile = 1 -- make <C-6> go back to prev file, not netrw
+vim.g.netrw_localcopydircmd = "cp -r" -- allow whole folder copying
 vim.api.nvim_create_autocmd("filetype", {
-	pattern = "netrw",
+	pattern = "netrw", -- netrw configuration, see https://vonheikemen.github.io/devlog/tools/using-netrw-vim-builtin-file-explorer/
 	callback = function()
-		-- https://vonheikemen.github.io/devlog/tools/using-netrw-vim-builtin-file-explorer/
-		vim.g.netrw_banner = 0
-		vim.g.netrw_winsize = 30
-		vim.g.netrw_altfile = 1 -- make <C-6> go back to prev file, not netrw
-		vim.g.netrw_localcopydircmd = "cp -r" -- allow whole folder copying
 		function NetrwWinBar()
 			return "%#Normal#  %t %*%=%#Normal# 󰋞 " .. vim.fn.getcwd() .. " "
 		end
@@ -145,33 +141,7 @@ vim.api.nvim_create_autocmd("filetype", {
 	end,
 })
 
--- TODO extend this to handle loclist - grr does qflist in 0.11, gO populates loclist
--- What was previously in /after/ftplugin/qf.lua
-vim.api.nvim_create_autocmd("filetype", {
-	pattern = "qf",
-	callback = function()
-		vim.keymap.set("n", "<C-n>", "<cmd>cnext | wincmd p<cr>", { remap = true, buffer = true })
-		vim.keymap.set("n", "<C-p>", "<cmd>cprev | wincmd p<cr>", { remap = true, buffer = true })
-		vim.keymap.set("n", "x", function()
-			-- use x to filter __highlighted__ entries from the qf list
-			local qf = vim.fn.getqflist({ idx = 0, items = 0 })
-			local current_idx = qf.idx
-
-			local new_qf_list = {}
-
-			for k, v in pairs(qf.items) do
-				if k ~= current_idx then
-					table.insert(new_qf_list, v)
-				end
-			end
-
-			vim.fn.setqflist(new_qf_list)
-		end, { remap = true, buffer = true })
-		vim.cmd("wincmd K")
-	end,
-})
-
--- NVIM.KEYBINDS
+-- ## NVIM.KEYBINDS
 vim.keymap.set("n", "<Esc>", function()
 	local filetype = vim.bo.filetype
 	local is_netrw = filetype == "netrw"
@@ -188,7 +158,7 @@ vim.keymap.set("n", "<Esc>", function()
 end, { silent = true })
 vim.keymap.set("n", "<leader>e", "<cmd>Ex<cr>", { silent = true })
 
--- NVIM.OPTIONS
+-- ## NVIM.OPTIONS
 vim.o.guicursor = vim.o.guicursor .. ",a:Cursor" -- append hl-Cursor to all modes
 vim.o.winborder = "rounded"
 vim.opt.background = "dark"
@@ -214,7 +184,6 @@ vim.opt.softtabstop = 4
 vim.opt.splitbelow = true
 vim.opt.splitright = true
 vim.opt.swapfile = false
--- TODO create way to toggle this easily, as lots of TS projects use 2.
 vim.opt.tabstop = 4
 vim.opt.termguicolors = true
 vim.opt.undofile = true

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,9 +1,9 @@
 -- ## TODOS
 -- fix the hl+ hl group not working in the pax theme!
--- add the ability to start neovim with/without lsp using a flag
+-- add the ability to start neovim with/without lsp using a flag -- see line 71
 
 -- ## INTRO
-vim.g.mapleader = " "
+vim.g.vim.g.mapleader = " "
 vim.g.maplocalleader = " "
 vim.keymap.set({ "n", "v" }, " ", "<nop>", { silent = true })
 
@@ -68,6 +68,8 @@ require("nvim-surround").setup()
 
 -- ## NVIM.LSP
 vim.lsp.enable({ "lua_ls", "ts_ls", "eslint", "cssls", "nixd" })
+-- TODO >>> add a function to turn off and disable all clients, or alternatively
+-- start with them off and add a function to turn them all _on_
 
 -- ## NVIM.AUTOCOMMANDS
 vim.api.nvim_create_autocmd("VimEnter", {

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,7 +1,8 @@
 -- ## TODOS
 -- create a way to toggle all of the relevant tab settings to move between 2/4 widths
 -- create a supertab for moving through the qf list
--- fix the hl+ hl group not working!
+-- fix the hl+ hl group not working in the pax theme!
+
 -- ## INTRO
 vim.g.mapleader = " "
 vim.g.maplocalleader = " "
@@ -26,7 +27,6 @@ vim.keymap.set("n", "<leader>f", fzf.files)
 vim.keymap.set("n", "<leader>s", fzf.grep_project)
 vim.keymap.set("n", "<leader>h", fzf.helptags)
 vim.keymap.set("n", "<leader>o", fzf.treesitter)
-vim.keymap.set("n", "<leader>c", fzf.highlights)
 
 -- ## PLUGINS.CONFORM
 require("conform").setup({
@@ -69,14 +69,13 @@ require("nvim-surround").setup()
 
 -- ## NVIM.AUTOCOMMANDS
 vim.api.nvim_create_autocmd("VimEnter", {
-	pattern = "*",
 	callback = function()
 		if next(vim.fn.argv()) == nil then
 			require("fzf-lua").files() -- open fzf if started with no args
 		end
 	end,
 })
-vim.api.nvim_create_autocmd("filetype", {
+vim.api.nvim_create_autocmd("FileType", {
 	pattern = { "netrw", "qf", "help" }, -- no visual columns in these files
 	callback = function()
 		vim.opt_local.colorcolumn = ""
@@ -92,7 +91,7 @@ vim.g.netrw_localcopydircmd = "cp -r" -- allow whole folder copying
 function NetrwWinBar()
 	return "%#Normal#  %t %*%=%#Normal# 󰋞 " .. vim.fn.getcwd() .. " "
 end
-vim.api.nvim_create_autocmd("filetype", {
+vim.api.nvim_create_autocmd("FileType", {
 	pattern = "netrw",
 	callback = function()
 		vim.opt_local.winbar = "%{%v:lua.NetrwWinBar()%}"
@@ -103,7 +102,7 @@ vim.api.nvim_create_autocmd("filetype", {
 })
 
 -- ## NVIM.KEYBINDS
-vim.keymap.set("n", "<Esc>", function()
+local function super_escape()
 	local filetype = vim.bo.filetype
 	local is_netrw = filetype == "netrw"
 	local is_qf_or_help = filetype == "qf" or filetype == "help"
@@ -116,27 +115,26 @@ vim.keymap.set("n", "<Esc>", function()
 	elseif is_netrw then
 		vim.cmd("Rex")
 	end
-end, { silent = true })
+end
+vim.keymap.set("n", "<Esc>", super_escape, { silent = true })
 vim.keymap.set("n", "<leader>e", "<cmd>Ex<cr>", { silent = true })
 
 -- ## NVIM.OPTIONS
 vim.o.guicursor = vim.o.guicursor .. ",a:Cursor" -- append hl-Cursor to all modes
 vim.o.winborder = "rounded"
-vim.opt.background = "dark"
 vim.opt.breakindent = true
 vim.opt.clipboard = "unnamedplus"
 vim.opt.colorcolumn = "80"
 vim.opt.cursorcolumn = true
 vim.opt.cursorline = true
 vim.opt.expandtab = true
-vim.opt.fillchars = { eob = " ", wbr = "▀", vert = "█" } -- see unicode block
+vim.opt.fillchars = { wbr = "▀", vert = "█" } -- see unicode block
 vim.opt.ignorecase = true
 vim.opt.jumpoptions = "stack"
 vim.opt.laststatus = 0
 vim.opt.number = true
 vim.opt.ruler = false
 vim.opt.shiftwidth = 0 -- follow vim.opt.tabstop
-vim.opt.showcmd = false
 vim.opt.sidescrolloff = 7
 vim.opt.signcolumn = "no"
 vim.opt.smartcase = true

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,6 +1,4 @@
 -- ## TODOS
--- create a way to toggle all of the relevant tab settings to move between 2/4 widths
--- create a supertab for moving through the qf list
 -- fix the hl+ hl group not working in the pax theme!
 
 -- ## INTRO
@@ -102,6 +100,19 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- ## NVIM.KEYBINDS
+function SetTabSize(size)
+	size = size or 4
+	vim.opt.tabstop = size
+	vim.opt.shiftwidth = size
+	vim.opt.softtabstop = size
+end
+local function super_tab(direction) -- "next" / "previous"
+	if vim.fn.getqflist({ winid = 0 }).winid ~= 0 then
+		return "<cmd>" .. "c" .. direction .. "<CR>"
+	end
+
+	return direction == "next" and "<Tab>" or "<S-Tab>"
+end
 local function super_escape()
 	local filetype = vim.bo.filetype
 	local is_netrw = filetype == "netrw"
@@ -118,8 +129,16 @@ local function super_escape()
 end
 vim.keymap.set("n", "<Esc>", super_escape, { silent = true })
 vim.keymap.set("n", "<leader>e", "<cmd>Ex<cr>", { silent = true })
+vim.keymap.set("n", "<leader>t", [[:lua SetTabSize()<Left>]], { noremap = true })
+vim.keymap.set("n", "<Tab>", function()
+	return super_tab("next")
+end, { noremap = true, expr = true, silent = true })
+vim.keymap.set("n", "<S-Tab>", function()
+	return super_tab("previous")
+end, { noremap = true, expr = true, silent = true })
 
 -- ## NVIM.OPTIONS
+SetTabSize()
 vim.o.guicursor = vim.o.guicursor .. ",a:Cursor" -- append hl-Cursor to all modes
 vim.o.winborder = "rounded"
 vim.opt.breakindent = true
@@ -134,22 +153,20 @@ vim.opt.jumpoptions = "stack"
 vim.opt.laststatus = 0
 vim.opt.number = true
 vim.opt.ruler = false
-vim.opt.shiftwidth = 0 -- follow vim.opt.tabstop
 vim.opt.sidescrolloff = 7
 vim.opt.signcolumn = "no"
 vim.opt.smartcase = true
 vim.opt.smartindent = true
-vim.opt.softtabstop = 4
 vim.opt.splitbelow = true
 vim.opt.splitright = true
 vim.opt.swapfile = false
-vim.opt.tabstop = 4
 vim.opt.termguicolors = true
 vim.opt.undofile = true
 function WinBar()
 	local icon = vim.bo.modified and "" or ""
 	return "%*%=%#Normal# " .. icon .. " %t %*%="
 end
+
 vim.opt.winbar = "%{%v:lua.WinBar()%}"
 
 vim.cmd("colorscheme pax")


### PR DESCRIPTION
Tidy up the config by removing redundant/irrelevant fluff.

Attempted to take lsp out, but that felt like a bit much, so just disabled it by default instead! call `:lua vim.lsp.enable("name")` to turn on an individual lsp server!