### PR TITLE
feat: translate nix profile to brew and mise

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,29 @@
+# Shell & terminal
+brew "stow"
+brew "tmux"
+brew "fzf"
+brew "ripgrep"
+brew "fd"
+brew "jq"
+
+# Version & runtime management
+brew "mise"
+
+# Editor & TUI
+brew "neovim"
+brew "yazi"
+brew "lazygit"
+
+# Language servers, linters, formatters
+brew "bash-language-server"
+brew "shellcheck"
+brew "lua-language-server"
+brew "stylua"
+brew "biome"
+brew "prettierd"
+brew "nixd"
+brew "alejandra"
+
+# GUI
+cask "ghostty"
+cask "nikitabobko/tap/aerospace"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ brew bundle --file=~/.dotfiles/Brewfile
 3. Stow the config folders:
 
 ```bash
-cd ~/.dotfiles && stow aerospace tmux ghostty [nix | mise] direnv nvim [zsh | bash]
+cd ~/.dotfiles && stow aerospace tmux ghostty [nix | mise] nvim [zsh | bash]
 ```
 
 Note that the shellrc files are designed to read local system spec from a sibling `.shellrc.local` file for local configuration mutations (to handle things like nvm, brew etc.).

--- a/README.md
+++ b/README.md
@@ -16,16 +16,22 @@ This repo is designed to be used anywhere by:
 cd && git clone --recurse-submodules https://github.com/artcodespace/.dotfiles.git
 ```
 
-2a. Install dependencies using nix:
+2a. Install nix then use that for dependencies:
 
 ```bash
 nix profile add ~/.dotfiles
 ```
 
+2b. Install Homebrew then use that for dependencies:
+
+```bash
+brew bundle --file=~/.dotfiles/Brewfile
+```
+
 3. Stow the config folders:
 
 ```bash
-cd ~/.dotfiles && stow aerospace tmux ghostty nix direnv nvim [zsh | bash]
+cd ~/.dotfiles && stow aerospace tmux ghostty [nix | mise] direnv nvim [zsh | bash]
 ```
 
 Note that the shellrc files are designed to read local system spec from a sibling `.shellrc.local` file for local configuration mutations (to handle things like nvm, brew etc.).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This repo is designed to be used anywhere by:
 
 - cloning the repo
-- using the flake to install dependencies with nix
+- installing the dependencies using:
+  - EITHER nix
+  - OR homebrew
 - symlinking (stowing) the dotfiles to the correct location
 
 # Tooling configuration steps
@@ -14,7 +16,7 @@ This repo is designed to be used anywhere by:
 cd && git clone --recurse-submodules https://github.com/artcodespace/.dotfiles.git
 ```
 
-2. Install dependencies using nix:
+2a. Install dependencies using nix:
 
 ```bash
 nix profile add ~/.dotfiles

--- a/README.md
+++ b/README.md
@@ -34,14 +34,24 @@ brew bundle --file=~/.dotfiles/Brewfile
 cd ~/.dotfiles && stow aerospace tmux ghostty [nix | mise] nvim [zsh | bash]
 ```
 
+4a. Expose nix applications to spotlight:
+
+```bash
+art-spotlight-nix-applications.sh
+```
+
+4b. Install Mise dependencies if using brew:
+
+```bash
+mise install
+```
+
 Note that the shellrc files are designed to read local system spec from a sibling `.shellrc.local` file for local configuration mutations (to handle things like nvm, brew etc.).
 
 They also assume secrets are kept in `~/.secrets` in the form `export SECRET=VALUE`.
 
 # TODO
 
-- Aerospace:
-  - setup for general work/admin split
 - Nix:
   - look at dir env integration for dev shell investigation work
 - Tmux:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repo is designed to be used anywhere by:
 
 - cloning the repo
 - installing the dependencies using:
-  - EITHER nix
-  - OR homebrew
+  - [EITHER nix](https://determinate.systems/nix-installer/)
+  - [OR homebrew](https://brew.sh/)
 - symlinking (stowing) the dotfiles to the correct location
 
 # Tooling configuration steps
@@ -34,7 +34,7 @@ brew bundle --file=~/.dotfiles/Brewfile
 cd ~/.dotfiles && stow aerospace tmux ghostty [nix | mise] nvim [zsh | bash]
 ```
 
-4a. Expose nix applications to spotlight:
+4a. Expose nix applications to spotlight (macOS only):
 
 ```bash
 art-spotlight-nix-applications.sh
@@ -52,7 +52,5 @@ They also assume secrets are kept in `~/.secrets` in the form `export SECRET=VAL
 
 # TODO
 
-- Nix:
-  - look at dir env integration for dev shell investigation work
 - Tmux:
   - figure out worktree workflow

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -27,6 +27,5 @@ PROMPT_COMMAND="_set_prompt"
 [[ -f ~/.secrets ]] && source ~/.secrets
 export PATH="$HOME/.dotfiles/scripts:$PATH"
 
-eval "$(direnv hook bash)"
 eval "$(mise activate bash)"
 source <(fzf --bash)

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -28,4 +28,5 @@ PROMPT_COMMAND="_set_prompt"
 export PATH="$HOME/.dotfiles/scripts:$PATH"
 
 eval "$(direnv hook bash)"
+eval "$(mise activate bash)"
 source <(fzf --bash)

--- a/direnv/.config/direnv/direnvrc
+++ b/direnv/.config/direnv/direnvrc
@@ -1,1 +1,0 @@
-source $HOME/.nix-profile/share/nix-direnv/direnvrc

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
             if platform == mac
             then
               # MAC SPECIFIC: TODO add aerospace back in
-              []
+              [aerospace]
             else []
           )
           ++ (

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
             # NOTE there is pkgs.stdenv.isDarwin
             if platform == mac
             then
-              # MAC SPECIFIC
+              # MAC SPECIFIC: TODO add aerospace back in
               []
             else []
           )

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,6 @@
             stow
             ghostty-bin
             tmux
-            direnv
-            nix-direnv
             unstablePkgs.neovim
             fzf
             lazygit

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
             # NOTE there is pkgs.stdenv.isDarwin
             if platform == mac
             then
-              # MAC SPECIFIC: TODO add aerospace back in
+              # MAC SPECIFIC
               [aerospace]
             else []
           )

--- a/mise/.config/mise/config.toml
+++ b/mise/.config/mise/config.toml
@@ -1,0 +1,8 @@
+[tools]
+node = "24"
+"npm:yarn" = "latest"
+"npm:typescript" = "latest"
+"npm:nodemon" = "latest"
+"npm:eslint" = "latest"
+"npm:vscode-langservers-extracted" = "latest"
+"npm:typescript-language-server" = "latest"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -21,6 +21,5 @@ PROMPT='${c_icon}${i_duck} ${c_path}%~${_branch:+ ${c_branch}${i_branch} ${_bran
 [[ -f ~/.secrets ]] && source ~/.secrets
 export PATH="$HOME/.dotfiles/scripts:$PATH"
 
-eval "$(direnv hook zsh)"
 eval "$(mise activate zsh)"
 source <(fzf --zsh)

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -22,4 +22,5 @@ PROMPT='${c_icon}${i_duck} ${c_path}%~${_branch:+ ${c_branch}${i_branch} ${_bran
 export PATH="$HOME/.dotfiles/scripts:$PATH"
 
 eval "$(direnv hook zsh)"
+eval "$(mise activate zsh)"
 source <(fzf --zsh)


### PR DESCRIPTION
For redundancy, split and move profile flake out to brew and mise, update readme for the parallel installation path.